### PR TITLE
feat: ownable contract and cooldownPeriod setter

### DIFF
--- a/foundry/src/IFoxStaking.sol
+++ b/foundry/src/IFoxStaking.sol
@@ -9,9 +9,32 @@ struct StakingInfo {
 }
 
 
-/// @title WIP high-level interface for FOX token staking contract
 /// @notice This interface outlines the functions for staking FOX tokens, managing RUNE addresses for rewards, and claiming 'em.
 interface IFoxStaking {
+    /// @notice Pauses deposits
+    function pauseStaking() external;
+
+    /// @notice Unpauses deposits
+    function unpauseStaking() external;
+
+    /// @notice Pauses withdrawals
+    function pauseWithdrawals() external;
+
+    /// @notice Unpauses withdrawals
+    function unpauseWithdrawals() external;
+
+    /// @notice Pauses unstaking
+    function pauseUnstaking() external;
+
+    /// @notice Unpauses unstaking
+    function unpauseUnstaking() external;
+
+    // @notice Sets contract-level paused state
+    function pause() external;
+
+    /// @notice Sets contract-level unpaused state
+    function unpause() external;
+
     /// @notice Allows a user to stake a specified amount of FOX tokens and assign a RUNE address for rewards - which can be changed later on.
     /// This has to be initiated by the user itself i.e msg.sender only, cannot be called by an address for another
     /// @param amount The amount of FOX tokens to be staked.


### PR DESCRIPTION
### Description

- Makes FOXStaking ownable - owned by the deployer
- Adds a setter for  `cooldownPeriod` - with `onlyOwner` modifier
- Adds unit tests for the setter ensuring `onlyOwner` is honored

### Issue

- contributes to https://github.com/shapeshift/rFOX/issues/6
<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"feat_accounting","parentHead":"c6733fe772124534e5f1abcb5bfb5e0c17b53072","parentPull":2,"trunk":"main"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"feat_accounting","parentHead":"c6733fe772124534e5f1abcb5bfb5e0c17b53072","parentPull":2,"trunk":"main"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
