### PR TITLE
fix: use anvil for local rewards distribution script contract deployments

### DIFF
--- a/foundry/script/DeployMockFoxToken.s.sol
+++ b/foundry/script/DeployMockFoxToken.s.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.25;
+
+import "forge-std/Script.sol";
+import {MockFOXToken} from "../test/utils/MockFOXToken.sol";
+
+contract DeployMockFoxToken is Script {
+    function run() public {
+        vm.startBroadcast();
+        MockFOXToken mockFoxToken = new MockFOXToken();
+        vm.stopBroadcast();
+
+        console.log("Contract deployed at:", address(mockFoxToken));
+    }
+}

--- a/scripts/rewards-distribution/constants.ts
+++ b/scripts/rewards-distribution/constants.ts
@@ -1,19 +1,25 @@
 import { createPublicClient, createWalletClient, http } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
 import { localhost } from "viem/chains";
-
-const ANVIL_JSON_RPC_URL = "http://127.0.0.1:8545";
 
 export const localChain = {
   ...localhost,
   id: 31337,
 } as const;
 
-export const localWalletClient = createWalletClient({
+export const localOwnerWalletClient = createWalletClient({
   chain: localChain,
-  transport: http(ANVIL_JSON_RPC_URL),
+  account: privateKeyToAccount(process.env.OWNER_PRIVATE_KEY as `0x${string}`),
+  transport: http(process.env.ANVIL_JSON_RPC_URL),
+});
+
+export const localUserWalletClient = createWalletClient({
+  chain: localChain,
+  account: privateKeyToAccount(process.env.USER_PRIVATE_KEY as `0x${string}`),
+  transport: http(process.env.ANVIL_JSON_RPC_URL),
 });
 
 export const localPublicClient = createPublicClient({
   chain: localChain,
-  transport: http(ANVIL_JSON_RPC_URL),
+  transport: http(process.env.ANVIL_JSON_RPC_URL),
 });

--- a/scripts/rewards-distribution/events.ts
+++ b/scripts/rewards-distribution/events.ts
@@ -1,81 +1,52 @@
-import { AbiEvent, Address, Log, parseEventLogs } from "viem";
+import { Log, getAbiItem } from "viem";
+import { stakingV1Abi } from "./generated/abi-types";
 
-type StakingEventName = "Stake" | "Unstake";
+export const stakeEvent = getAbiItem({ abi: stakingV1Abi, name: "Stake" });
+export const unstakeEvent = getAbiItem({ abi: stakingV1Abi, name: "Unstake" });
+export const updateCooldownPeriodEvent = getAbiItem({
+  abi: stakingV1Abi,
+  name: "UpdateCooldownPeriod",
+});
+export const withdrawEvent = getAbiItem({
+  abi: stakingV1Abi,
+  name: "Withdraw",
+});
+export const setRuneAddressEvent = getAbiItem({
+  abi: stakingV1Abi,
+  name: "SetRuneAddress",
+});
 
-type StakingAbiEvent<T extends StakingEventName> = {
-  type: "event";
-  anonymous: false;
-  inputs: [
-    {
-      name: "account";
-      type: "address";
-      indexed: true;
-    },
-    {
-      name: "amount";
-      type: "uint256";
-      indexed: false;
-    },
-    // TOOD(gomes): if runeAddress is part of the staking fn, then it should be part of the Stake event too and should be reflected here
-  ];
-  name: T;
-};
+export const rFoxEvents = [
+  stakeEvent,
+  unstakeEvent,
+  updateCooldownPeriodEvent,
+  withdrawEvent,
+  setRuneAddressEvent,
+] as const;
 
-type GenericStakingEventLog<T extends StakingEventName> = Log<
+export type RFoxEvent = (typeof rFoxEvents)[number];
+
+export type StakeLog = Log<bigint, number, false, typeof stakeEvent, true>;
+export type UnstakeLog = Log<bigint, number, false, typeof unstakeEvent, true>;
+export type UpdateCooldownPeriodLog = Log<
   bigint,
   number,
   false,
-  AbiEvent,
-  true,
-  StakingAbiEvent<T>[],
-  T
+  typeof updateCooldownPeriodEvent,
+  true
+>;
+export type WithdrawLog = Log<bigint, number, false, typeof withdrawEvent>;
+export type SetRuneAddressLog = Log<
+  bigint,
+  number,
+  false,
+  typeof setRuneAddressEvent,
+  true
 >;
 
-// explicit union of all possible event logs to ensure event args are correctly parsed by ts (fixes defaulting to unknown)
-export type StakingEventLog =
-  | GenericStakingEventLog<"Stake">
-  | GenericStakingEventLog<"Unstake">;
-
-const addressA: Address = "0xA";
-const addressB: Address = "0xB";
-const addressC: Address = "0xC";
-const addressD: Address = "0xD";
-const addressE: Address = "0xE";
-
-export type StakingLog = Pick<
-  StakingEventLog,
-  "blockNumber" | "eventName" | "args"
->;
-
-export const logs: StakingLog[] = [
-  {
-    blockNumber: 20n,
-    eventName: "Stake",
-    args: { account: addressA, amount: 100n },
-  },
-  {
-    blockNumber: 25n,
-    eventName: "Stake",
-    args: { account: addressB, amount: 150n },
-  },
-  {
-    blockNumber: 32n,
-    eventName: "Stake",
-    args: { account: addressC, amount: 10000n },
-  },
-  {
-    blockNumber: 33n,
-    eventName: "Stake",
-    args: { account: addressD, amount: 1200n },
-  },
-  {
-    blockNumber: 60n,
-    eventName: "Unstake",
-    args: { account: addressA, amount: 100n },
-  },
-  {
-    blockNumber: 65n,
-    eventName: "Stake",
-    args: { account: addressE, amount: 500n },
-  },
-];
+export type RFoxLog =
+  | StakeLog
+  | UnstakeLog
+  | UpdateCooldownPeriodLog
+  | WithdrawLog
+  | SetRuneAddressLog;

--- a/simulate-rewards-distribution.sh
+++ b/simulate-rewards-distribution.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -ex
+
+forge clean --root foundry
+
+# Default private keys from anvil, assuming the default mnemonic
+# "test test test test test test test test test test test junk"
+export OWNER_PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+export USER_PRIVATE_KEY=0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
+export ANVIL_JSON_RPC_URL="http://127.0.0.1:8545"
+
+# Deploy the mock FOX token as the staking token
+stakingTokenDeployOutput=$(
+  forge script foundry/script/DeployMockFoxToken.s.sol:DeployMockFoxToken \
+    --root foundry \
+    --broadcast \
+    --rpc-url http://127.0.0.1:8545 \
+    --private-key $OWNER_PRIVATE_KEY \
+    -vvv
+)
+stakingTokenAddress=$(echo "$stakingTokenDeployOutput" | grep "Contract deployed at:" | awk '{print $4}')
+export STAKING_TOKEN_ADDRESS=$stakingTokenAddress
+
+# Deploy the staking proxy
+stakingProxyDeployOutput=$(
+  forge script foundry/script/DeployStaking.s.sol:DeployStaking \
+    --root foundry \
+    --broadcast \
+    --rpc-url http://127.0.0.1:8545 \
+    --private-key $OWNER_PRIVATE_KEY \
+    -vvv
+)
+stakingProxyAddress=$(echo "$stakingProxyDeployOutput" | grep "Contract deployed at:" | awk '{print $4}')
+export STAKING_PROXY_ADDRESS=$stakingProxyAddress
+
+# Run the rewards distribution simulation
+ts-node scripts/rewards-distribution/index.ts


### PR DESCRIPTION
Relates to #10 

Brings the original rewards distribution script back into a working state with our upgradeable proxy.

Performs contract deployment to local fork via anvil which also uses our production-ready contract deploy script to ensure the proxy is correctly deployed with initialization. 

Adds some extra debugging, safer/corrected log parsing and type safety improvements.

Doesn't actually change or improve the original staking rewards script flow and logic - this will be done in follow-up task.