### PR TITLE
adds additional comments to warn about indexing events for rune address

### DIFF
--- a/foundry/src/StakingV1.sol
+++ b/foundry/src/StakingV1.sol
@@ -35,7 +35,7 @@ contract StakingV1 is
     uint256 public rewardPerTokenStored;
 
     event UpdateCooldownPeriod(uint256 newCooldownPeriod);
-    
+
     /// @notice emits an event for when a user stakes tokens
     /// @dev WARNING: a user can also update their address with setRuneAddress
     /// @param account the address of the account that called stake
@@ -53,8 +53,8 @@ contract StakingV1 is
         uint256 cooldownExpiry
     );
     event Withdraw(address indexed account, uint256 amount);
-    
-    /// @notice emits and event for when user calls setRuneAddress
+
+    /// @notice emits an event for when user calls setRuneAddress
     /// @dev WARNING: this event is not fired when a user calls stake and sets a rune address through that function.
     /// Please see the Stake event for that information.
     /// @param account The address of the account that called setRuneAddress
@@ -65,7 +65,7 @@ contract StakingV1 is
         string indexed oldRuneAddress,
         string indexed newRuneAddress
     );
-    
+
     event StakingPausedChanged(bool isPaused);
     event WithdrawalsPausedChanged(bool isPaused);
     event UnstakingPausedChanged(bool isPaused);


### PR DESCRIPTION
@trust1995 recommended we add some additional documentation regarding some of the inconsistencies with the `SetRuneAddress` event not being fired when `stake` is called