### PR TITLE
fix: update type to match api

### DIFF
--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -21,7 +21,7 @@ const ARBITRUM_RFOX_PROXY_CONTRACT_ADDRESS = '0xac2a4fd70bcd8bab0662960455c36373
 const THORCHAIN_PRECISION = 8
 
 type Revenue = {
-  address: string
+  address: string[]
   amount: string
 }
 

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -21,7 +21,7 @@ const ARBITRUM_RFOX_PROXY_CONTRACT_ADDRESS = '0xac2a4fd70bcd8bab0662960455c36373
 const THORCHAIN_PRECISION = 8
 
 type Revenue = {
-  address: string[]
+  addresses: string[]
   amount: string
 }
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -45,7 +45,7 @@ const processEpoch = async () => {
   const revenue = await client.getRevenue(metadata.epochStartTimestamp, metadata.epochEndTimestamp)
 
   info(
-    `Total ${month} revenue earned by ${revenue.address}: ${BigNumber(revenue.amount).div(100000000).toFixed(8)} RUNE`,
+    `Total ${month} revenue earned by ${revenue.addresses}: ${BigNumber(revenue.amount).div(100000000).toFixed(8)} RUNE`,
   )
 
   info(`Share of total revenue to be distributed as rewards: ${metadata.distributionRate * 100}%`)


### PR DESCRIPTION
changes type to string[] to match return from the api 

for example

https://api.thorchain.shapeshift.com/api/v1/affiliate/revenue?start=1727740800000&end=1730419199999