### PR TITLE
fix: rate limits and block timestamps

### DIFF
--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -81,14 +81,13 @@ export class Client {
       let blockNumber = latestBlock.number - targetBlocksToMove
       while (true) {
         if (blockNumber <= 0n) return 0n
-
         const block = await this.rpc.getBlock({ blockNumber })
-
         const timeDifferenceSeconds = targetTimestamp - block.timestamp
 
         // Block is within 1 block before the target timestamp
-        if (timeDifferenceSeconds >= 0n && timeDifferenceSeconds <= averageBlockTimeSeconds) break
-
+        // Math.ceil is used for averageBlockTimeSeconds because if its sub second, we will never converge
+        // on a solution.
+        if (timeDifferenceSeconds >= 0n && timeDifferenceSeconds <= Math.ceil(averageBlockTimeSeconds)) break
         const blocksToMove = BigInt(Math.ceil(Math.abs(Number(timeDifferenceSeconds)) / averageBlockTimeSeconds))
 
         if (block.timestamp > targetTimestamp) {
@@ -96,6 +95,8 @@ export class Client {
         } else {
           blockNumber += blocksToMove
         }
+        // sleep momentarily to avoid rate limiting
+        await new Promise(resolve => setTimeout(resolve, 100))
       }
 
       // In case of multiple batched blocks for a target timestamp, find the earliest or latest block based on blockMode
@@ -110,6 +111,8 @@ export class Client {
         if (block.timestamp !== targetTimestamp) break
 
         blockNumber = nextBlockNumber
+        // sleep momentarily to avoid rate limiting
+        await new Promise(resolve => setTimeout(resolve, 100))
       }
 
       return blockNumber
@@ -199,6 +202,8 @@ export class Client {
 
       const rewardUnits = totalRewardUnits - totalRewardUnitsPrevEpoch
 
+      // sleep momentarily to avoid rate limiting
+      await new Promise(resolve => setTimeout(resolve, 1000))
       if (rewardUnits <= 0) continue
 
       closingStateByStakingAddress[address] = { rewardUnits, totalRewardUnits, runeAddress }
@@ -255,7 +260,6 @@ export class Client {
       const addresses = [
         ...new Set(stakeEvents.map(event => event.args.account).filter(address => Boolean(address))),
       ] as Address[]
-
       const closingStateByStakingAddress = await this.getClosingStateByStakingAddress(addresses, startBlock, endBlock)
       const distributionsByStakingAddress = await this.getDistributionsByStakingAddress(
         closingStateByStakingAddress,
@@ -299,7 +303,7 @@ export class Client {
           'The total reward distribution calculated for all stakers is outside of the expected .01% margin of the total rewards to be distributed.',
         )
 
-        info(`Total Distribtution Calculated: ${totalEpochDistribution.div(100000000).toFixed()} RUNE`)
+        info(`Total Distribution Calculated: ${totalEpochDistribution.div(100000000).toFixed()} RUNE`)
         info(`Total Epoch Distribution: ${totalDistribution.div(100000000).toFixed()} RUNE`)
 
         const confirmed = await prompts.confirm({ message: 'Do you want to continue? ' })


### PR DESCRIPTION
This PR fixes two problems:

rate limits: This lazily solves our rate limiting issues when using infura to process the epoch.  In the future we may want to introduce a retry mechanism with delay which would be a much more resilient solution. 

start / end block bug: previously we could end up in a state where we never would find the ideal block and instead oscillate between blocks indefinitely. This resolves that issue.  One note is that this is not a deterministic process and its possible to process the same epoch again and select a different end block that is still the correct timestamp. 

